### PR TITLE
Fix ReDoS vulnerability in starlette

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ six==1.16.0
 sniffio==1.3.0
 SQLAlchemy==2.0.23
 stack-data==0.6.3
-starlette==0.27.0
+starlette>=0.36.2
 sympy==1.12
 threadpoolctl==3.2.0
 timm==0.9.11


### PR DESCRIPTION
Upgrading starlette to v0.36.2 to address the reported ReDoS vulnerability.